### PR TITLE
Add `coverage` task and enforce at least a 80% code coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,3 +52,12 @@ jobs:
             cd ../..
             echo "::endgroup::"
           done
+      - name: Check code covegare
+        run: |
+          for d in */*; do
+            echo "::group::Checking code coverage for ${d}"
+            cd "$d"
+            task coverage
+            cd ../..
+            echo "::endgroup::"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cover.out

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,6 +22,19 @@ tasks:
     cmds:
       - gofmt -l . | awk '{ print } END { exit(NR > 0) }'
 
+  coverage:
+    desc: Check Go code coverage.
+    summary: |
+      Check Go code coverage
+
+      Test the Go code enabling coverage analysis, generates a coverprofile as
+      `cover.out` and check that the total coverage of the code is >=80%.
+    dir: '{{.USER_WORKING_DIR}}'
+    cmds:
+      - go test -v -cover -coverprofile cover.out ./...
+      - "go tool cover -func=cover.out | awk -v acceptable=80 '/^total:/ { coverage = $NF } END { print \"Total coverage: \" coverage; if (coverage + 0 >= acceptable) { exit 0 } exit 1 }'"
+
+
   fmt:
     desc: Format Go code.
     summary: |


### PR DESCRIPTION
This PR adds `cover.out` to `.gitignore` that is the default coverage profile file generated as part of `task coverage`.

It then adds a `coverage` task that run `go test` with coverage enabled and do some AWK-fu to extract the total code coverage and exit with errors if there is not enough code coverage (at the moment 80%).

Finally, it enables all of that in the GitHub Actions workflows.

For possible more information please give a look to each single commit and commit messages.
