### PR TITLE
Use %v verb to print arrays

### DIFF
--- a/01-sorting-and-searching/01-bubble-sort/bubblesort/bubblesort_test.go
+++ b/01-sorting-and-searching/01-bubble-sort/bubblesort/bubblesort_test.go
@@ -33,7 +33,7 @@ func TestBubbleSort(t *testing.T) {
 			BubbleSort(tc.array)
 
 			if !utils.IsSorted(tc.array) {
-				t.Errorf("got: %q, not sorted", tc.array)
+				t.Errorf("got: %v, not sorted", tc.array)
 			}
 		})
 	}

--- a/01-sorting-and-searching/01-bubble-sort/utils/utils_test.go
+++ b/01-sorting-and-searching/01-bubble-sort/utils/utils_test.go
@@ -173,7 +173,7 @@ func TestSorted(t *testing.T) {
 			sorted := IsSorted(tc.array)
 
 			if sorted != tc.sorted {
-				t.Errorf("expected: %t, got: %t for array %q",
+				t.Errorf("expected: %t, got: %t for array %v",
 					tc.sorted, sorted, tc.array)
 			}
 		})


### PR DESCRIPTION
The `%q` verb will threat elements in the arrays as characters that is not very nice for array of ints.

Switch to `%v` so the integers are printed as is with their numeric values.
