### PR TITLE
Spell coverage correctly

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,7 +52,7 @@ jobs:
             cd ../..
             echo "::endgroup::"
           done
-      - name: Check code covegare
+      - name: Check code coverage
         run: |
           for d in */*; do
             echo "::group::Checking code coverage for ${d}"


### PR DESCRIPTION
Fix a tyop in the GitHub Actions workflow step.

NFCI.
