### PR TITLE
Pass an empty policy for conftest v0.61.0 to preserve the old behavior

### DIFF
--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -18,4 +18,4 @@ jobs:
         env:
           CONFTEST_POLICIES: git::https://github.com/iamleot/conftest-policies.git//policy/github
         with:
-          args: test --all-namespaces --update "${{ env.CONFTEST_POLICIES }}" .github/workflows
+          args: test --all-namespaces --policy '' --update "${{ env.CONFTEST_POLICIES }}" .github/workflows


### PR DESCRIPTION
conftest v0.61.0 broke the previous semantic and now to be able to use the `--update` as it was it is needed to unset the default policy.

Please see <https://github.com/open-policy-agent/conftest/issues/1136> for more information.
