### PR TITLE
Revoke all unneeded permissions to GitHub Actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,4 +1,5 @@
 name: Check GitHub Actions workflows
+permissions: {}
 
 'on':
   push:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Check GitHub Actions workflows
         uses: docker://rhysd/actionlint:latest
         with:

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -1,4 +1,5 @@
 name: Validate via personal conftest policies
+permissions: {}
 
 'on':
   push:

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Validate via personal conftest policies
         uses: docker://openpolicyagent/conftest:latest
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,5 @@
 name: Check, build and test Go code
+permissions: {}
 
 'on':
   push:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: '1.20'
       - name: Install Task

--- a/.github/workflows/mdformat.yml
+++ b/.github/workflows/mdformat.yml
@@ -1,4 +1,5 @@
 name: Check Markdown formatting via mdformat
+permissions: {}
 
 'on':
   push:

--- a/.github/workflows/mdformat.yml
+++ b/.github/workflows/mdformat.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install mdformat
         run: |
           pip install mdformat


### PR DESCRIPTION
Only "metadata" read permissions are actually needed and these are given by default also with `permissions: {}`.

`actions/checkout` says that `permissions.contents: read` is needed. However, for our use cases no contents operations are actually needed.

---

The permissions can be seen under each GitHub Actions workflow logs, under "Set up job", there is something like the following:

> GITHUB_TOKEN Permissions
>  Contents: read
>  Metadata: read
>  Packages: read

...or something:

> GITHUB_TOKEN Permissions
>   Actions: write
>   ArtifactMetadata: write
>   Attestations: write
>   Checks: write
>   Contents: write
>   Deployments: write
>   Discussions: write
>   Issues: write
>   Metadata: read
>   Models: read
>   Packages: write
>   Pages: write
>   PullRequests: write
>   RepositoryProjects: write
>   SecurityEvents: write
>   Statuses: write

And yeah, all these write-s are much more dangerous in case `GITHUB_TOKEN` gets leaked!

---

Please see <https://github.com/iamleot/rpi-flux/pull/190> for corresponding experiments too.
